### PR TITLE
feat: apply wizard UX redesign - 5-step flow, AI generate, card alignment

### DIFF
--- a/.squad/agents/danny/history.md
+++ b/.squad/agents/danny/history.md
@@ -323,3 +323,19 @@ Rusty's frontend restoration + Linus's backend handler = complete feature. No re
 - Risk mitigation strategies for both technical and organizational concerns
 
 **Key Learning:** Architecture roadmaps for stakeholders require balancing technical precision with executive accessibility. Use detailed Mermaid diagrams (not minimal sketches) to convey system complexity. Present three-phase approach (foundation → integration → automation) to show compounding value over time. Tie each phase to measurable business outcomes (time savings, adoption rates, quality metrics) rather than technical implementation details.
+
+### PR #40 Opened: PBI Studio UX Improvements (2026-04-30)
+
+**Branch:** feature/pbi-studio-ux-improvements  
+**PR URL:** https://github.com/ltnguyenJha/PO-Professional-Tools/pull/40  
+**Title:** feat(pbi-studio): UX improvements, wizard fixes, and AI-Generated Feature Definition
+
+**Summary of Changes:**
+- **UX Improvements:** Added "PBI Type" label, improved inactive button contrast, polished active pill with box-shadow; added AI-Generated hint label in Step 3
+- **Bug Fixes:** Fixed Business Rules navigation (onNext 4→5), removed Feature gate on Feature Definition step, aligned card padding to 16px
+- **New Feature:** AI-Generated Feature Definition button (generates why, userFlow, businessRules, userStoryStatement fields via Copilot)
+- **CSS Fixes:** Added numeric spacing scale (--space-1 through --space-8), added --color-primary-default and --color-error bridge variables, fixed undefined CSS variables
+
+**Build Status:** ✅ TypeScript: 0 errors, Webview build: green, Extension build: green
+
+**Key Learning:** Complete feature PRs combine UX polish, bug fixes, and new capabilities in a single coherent release. Comprehensive PR bodies with emoji sections (🎨 UX, 🐛 Bugs, ✨ Features, 🔧 Fixes) improve reviewer experience and documentation clarity. AI-Generated pattern (button → message → service → response) is now established across multiple wizard steps.

--- a/.squad/agents/tess/history.md
+++ b/.squad/agents/tess/history.md
@@ -47,9 +47,36 @@
 - Provides clear instructions on how to use AI-Generated mode (keyboard shortcut + right-click)
 - Reduces cognitive load and support questions
 
-(None yet — first day on the job. Will accumulate as work progresses.)
+### Card Alignment Consistency (2026-04-30)
+**Problem:**
+- The PBI Studio had multiple card types (`.card` for PBI edit panels, `.wizard-step` for wizard cards, `.pbi-type-selector-wrap`) with inconsistent spacing
+- `.card` was using legacy token names (`--radius-lg`, `--space-lg`, `--space-md`)
+- `.wizard-step` had more generous padding (`--space-5` = 20px) compared to standard cards (`--space-4` = 16px)
+- `.wizard-step` gap was also larger (`--space-5` vs `--space-3`)
+- This created visual misalignment where wizard cards felt "puffier" than edit cards
+
+**Solution:**
+- Normalized all card components to use consistent modern tokens:
+  - **Border radius:** `var(--radius-5)` = 12px (large, friendly corners)
+  - **Padding:** `var(--space-4)` = 16px (balanced internal spacing)
+  - **Internal gap:** `var(--space-3)` = 12px (comfortable element spacing)
+  - **Shadow:** `var(--shadow-sm)` (subtle elevation)
+  - **Border:** 1px solid `var(--line)` or `var(--color-neutral-300)`
+- Updated `.pbi-type-selector-wrap` margin-bottom to use `var(--space-4)` for consistency
+
+**Impact:**
+- All cards in PBI Studio now share a cohesive visual rhythm
+- Reduces cognitive load — users see one consistent "card" pattern, not multiple competing styles
+- Aligns with design system token migration (Phase 2) — using modern token names throughout
+- Easier maintenance — consistent spacing makes future adjustments simpler
+
+**Design Rationale:**
+- Chose `--space-4` (16px) as the standard card padding because it's the sweet spot: enough breathing room without feeling wasteful of screen real estate
+- Kept `--space-3` (12px) for internal gaps — creates visual hierarchy (outer padding > inner gap)
+- Using `--radius-5` (12px) gives cards a friendly, modern feel while maintaining VS Code's design language
 
 ## Session Log
 
 - **2026-04-30 09:07:** Tess joined the team. Charter established, ready for first assignment.
 - **2026-04-30 17:00:** Saul (UI Designer) joined roster as design partner to collaborate on component library and Feature Wizard refinement.
+- **2026-04-30 [current]:** Fixed card alignment consistency across PBI Studio (Issue: card spacing misalignment).

--- a/webview-ui/src/components/FeatureWizard.tsx
+++ b/webview-ui/src/components/FeatureWizard.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useVsCodeApi } from '../utils/useVsCodeApi';
 import type { PbiDraft } from '../types';
-import { WizardStep1Type } from './WizardStep1Type';
-import { WizardStep2Identity } from './WizardStep2Identity';
 import { WizardStep3Story } from './WizardStep3Story';
 import { WizardStepFeatureDefinition } from './WizardStepFeatureDefinition';
 import { WizardStep3p5BusinessRules } from './WizardStep3p5BusinessRules';
@@ -13,7 +11,7 @@ interface Props {
   draftId: string;
 }
 
-type StepName = 'Type' | 'Identity' | 'Story' | 'Feature Definition' | 'Business Rules' | 'Details' | 'Technical Considerations';
+type StepName = 'Story' | 'Feature Definition' | 'Business Rules' | 'Details' | 'Technical Considerations';
 
 export function FeatureWizard({ draftId }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
@@ -24,8 +22,9 @@ export function FeatureWizard({ draftId }: Props) {
   const [aiGenerating, setAiGenerating] = useState(false);
   const vscode = useVsCodeApi();
   const announcementRef = useRef<HTMLDivElement>(null);
+  const wasGeneratingRef = useRef(false);
 
-  const steps: StepName[] = ['Type', 'Identity', 'Story', 'Feature Definition', 'Business Rules', 'Details', 'Technical Considerations'];
+  const steps: StepName[] = ['Story', 'Feature Definition', 'Business Rules', 'Details', 'Technical Considerations'];
 
   // Announce step changes to screen readers
   useEffect(() => {
@@ -45,13 +44,19 @@ export function FeatureWizard({ draftId }: Props) {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;
       if (message.type === 'AI_PROGRESS') {
-        setAiGenerating(message.payload.busy);
+        const nowBusy = message.payload.busy;
+        if (wasGeneratingRef.current && !nowBusy && currentStep === 0) {
+          // Generation just finished — reload draft
+          vscode.postMessage({ type: 'WIZARD_DRAFT_LOAD', payload: { draftId } });
+        }
+        wasGeneratingRef.current = nowBusy;
+        setAiGenerating(nowBusy);
       }
     };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, []);
+  }, [currentStep, draftId, vscode]);
 
   // Load draft on mount
   useEffect(() => {
@@ -189,8 +194,8 @@ export function FeatureWizard({ draftId }: Props) {
               onClick={() => idx <= currentStep && handleStepChange(idx)}
               className={`wizard-progress-step ${idx === currentStep ? 'active' : ''} ${
                 idx < currentStep ? 'completed' : ''
-              } ${idx > currentStep || (draft.workItemType === 'Bug' && idx === 0) ? 'disabled' : ''}`}
-              disabled={idx > currentStep || (draft.workItemType === 'Bug' && idx === 0)}
+              } ${idx > currentStep ? 'disabled' : ''}`}
+              disabled={idx > currentStep}
               aria-label={`Step ${idx + 1}: ${stepName}${idx < currentStep ? ' (completed)' : idx === currentStep ? ' (current)' : ''}`}
             >
               <div className="wizard-progress-step-indicator" aria-hidden="true">{idx + 1}</div>
@@ -201,29 +206,16 @@ export function FeatureWizard({ draftId }: Props) {
 
         {/* Step content */}
         {currentStep === 0 && (
-          <WizardStep1Type
-            draft={draft}
-            onNext={(next) => handleStepChange(next)}
-          />
-        )}
-        {currentStep === 1 && (
-          <WizardStep2Identity
-            draft={draft}
-            onNext={(next) => handleStepChange(next)}
-            onBack={(prev) => handleStepChange(prev)}
-          />
-        )}
-        {currentStep === 2 && (
           <WizardStep3Story
             draft={draft}
             onNext={(next) => handleStepChange(next)}
-            onBack={(prev) => handleStepChange(prev)}
             onSave={handleSave}
             onGenerateAI={handleGenerateAI}
             onOpenInChat={handleOpenInChat}
+            isGenerating={aiGenerating}
           />
         )}
-        {currentStep === 3 && (
+        {currentStep === 1 && (
           <WizardStepFeatureDefinition
             draft={draft}
             onNext={(next) => handleStepChange(next)}
@@ -232,7 +224,7 @@ export function FeatureWizard({ draftId }: Props) {
             onGenerateAI={handleGenerateFeatureDefinition}
           />
         )}
-        {currentStep === 4 && (
+        {currentStep === 2 && (
           <WizardStep3p5BusinessRules
             draft={draft}
             onNext={(next) => handleStepChange(next)}
@@ -240,7 +232,7 @@ export function FeatureWizard({ draftId }: Props) {
             onSave={handleSave}
           />
         )}
-        {currentStep === 5 && (
+        {currentStep === 3 && (
           <WizardStep4Details
             draft={draft}
             onNext={(next) => handleStepChange(next)}
@@ -248,7 +240,7 @@ export function FeatureWizard({ draftId }: Props) {
             onSave={handleSave}
           />
         )}
-        {currentStep === 6 && (
+        {currentStep === 4 && (
           <WizardStep6TechnicalConsiderations
             draft={draft}
             isLoading={aiGenerating}

--- a/webview-ui/src/components/WizardStep3Story.tsx
+++ b/webview-ui/src/components/WizardStep3Story.tsx
@@ -5,10 +5,11 @@ import './WizardStep3Story.css';
 interface Props {
   draft: PbiDraft;
   onNext: (nextStep: number) => void;
-  onBack: (prevStep: number) => void;
+  onBack?: (prevStep: number) => void;
   onSave: (partialDraft: Partial<PbiDraft>) => void;
   onGenerateAI?: () => void;
   onOpenInChat?: () => void;
+  isGenerating?: boolean;
 }
 
 type AiMode = 'Manual' | 'AI-Generated';
@@ -20,6 +21,7 @@ export function WizardStep3Story({
   onSave,
   onGenerateAI,
   onOpenInChat,
+  isGenerating = false,
 }: Props) {
   const [aiMode, setAiMode] = useState<AiMode>('Manual');
   const [persona, setPersona] = useState('');
@@ -44,6 +46,19 @@ export function WizardStep3Story({
   useEffect(() => {
     firstFieldRef.current?.focus();
   }, []);
+
+  // Parse draft.description back into fields when AI updates it
+  useEffect(() => {
+    const desc = draft.description || '';
+    // Parse "As a X\nI want Y\nSo that Z" format
+    const lines = desc.split('\n');
+    const personaLine = lines.find(l => l.startsWith('As a '));
+    const wantLine = lines.find(l => l.startsWith('I want '));
+    const benefitLine = lines.find(l => l.startsWith('So that '));
+    if (personaLine) setPersona(personaLine.replace('As a ', ''));
+    if (wantLine) setWant(wantLine.replace('I want ', ''));
+    if (benefitLine) setBenefit(benefitLine.replace('So that ', ''));
+  }, [draft.description]);
 
   // Show AI toast once when AI mode is enabled for first time
   useEffect(() => {
@@ -72,7 +87,7 @@ export function WizardStep3Story({
     onSave({
       description: `As a ${persona}\nI want ${want}\nSo that ${benefit}`,
     });
-    onNext(3);
+    onNext(1);
   };
 
   const handleInvestToggle = (key: keyof typeof investChecks) => {
@@ -249,27 +264,33 @@ export function WizardStep3Story({
         </div>
       </div>
 
-      {/* AI action buttons removed — now AI-Ready indicator */}
+      {/* AI generate section */}
       {aiMode === 'AI-Generated' && (
-        <div 
-          className="ai-ready-indicator" 
-          role="status" 
-          aria-live="polite"
-          title="Press Ctrl+Shift+P to generate, or right-click any field to refine"
-        >
-          <span className="ai-indicator-icon">✨</span>
-          <span className="ai-indicator-text">AI-Ready</span>
+        <div className="ai-generate-section">
+          <button
+            className="wizard-btn wizard-btn-primary ai-generate-btn"
+            onClick={() => onGenerateAI?.()}
+            disabled={!onGenerateAI || isGenerating}
+            aria-label="Generate story using AI"
+          >
+            {isGenerating ? '⏳ Generating...' : '✨ Generate Story'}
+          </button>
+          <p className="wizard-mode-hint">
+            AI will draft your story based on the fields above. Fill in what you know, then let Copilot complete the rest.
+          </p>
         </div>
       )}
 
       <div className="wizard-actions">
-        <button 
-          className="wizard-btn wizard-btn-secondary" 
-          onClick={() => onBack(1)}
-          aria-label="Go back to previous step"
-        >
-          Back
-        </button>
+        {onBack && (
+          <button 
+            className="wizard-btn wizard-btn-secondary" 
+            onClick={() => onBack(0)}
+            aria-label="Go back to previous step"
+          >
+            Back
+          </button>
+        )}
         <button 
           className="wizard-btn wizard-btn-primary" 
           onClick={handleNext}

--- a/webview-ui/src/components/WizardStep3p5BusinessRules.tsx
+++ b/webview-ui/src/components/WizardStep3p5BusinessRules.tsx
@@ -35,7 +35,7 @@ export function WizardStep3p5BusinessRules({
   const handleNext = () => {
     if (saveTimer) clearTimeout(saveTimer);
     onSave({ businessRulesAndAssumptions: businessRules });
-    onNext(5);
+    onNext(3);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -77,7 +77,7 @@ export function WizardStep3p5BusinessRules({
       <div className="wizard-actions">
         <button 
           className="wizard-btn wizard-btn-secondary" 
-          onClick={() => onBack(2)}
+          onClick={() => onBack(1)}
           aria-label="Go back to previous step"
         >
           Back

--- a/webview-ui/src/components/WizardStep4Details.tsx
+++ b/webview-ui/src/components/WizardStep4Details.tsx
@@ -57,7 +57,7 @@ export function WizardStep4Details({ draft, onNext, onBack, onSave }: Props) {
       testScenarios: testCases.map((tc) => `${tc.description} → ${tc.expected}`),
       attachments,
     });
-    onNext(5); // Would go to summary or submit
+    onNext(4); // Would go to summary or submit
   };
 
   const handleAddFile = () => {
@@ -226,7 +226,7 @@ export function WizardStep4Details({ draft, onNext, onBack, onSave }: Props) {
       </div>
 
       <div className="wizard-actions">
-        <button className="wizard-btn wizard-btn-secondary" onClick={() => onBack(3)}>
+        <button className="wizard-btn wizard-btn-secondary" onClick={() => onBack(2)}>
           Back
         </button>
         <button
@@ -242,10 +242,10 @@ export function WizardStep4Details({ draft, onNext, onBack, onSave }: Props) {
               testScenarios: testCases.map((tc) => `${tc.description} → ${tc.expected}`),
               attachments,
             });
-            onNext(5); // Submit/complete
+            onNext(4); // Submit/complete
           }}
         >
-          Complete
+          Next
         </button>
       </div>
     </div>

--- a/webview-ui/src/components/WizardStep6TechnicalConsiderations.tsx
+++ b/webview-ui/src/components/WizardStep6TechnicalConsiderations.tsx
@@ -188,7 +188,7 @@ export function WizardStep6TechnicalConsiderations({
       <div style={{ display: 'flex', gap: 'var(--space-2)', marginTop: 'var(--space-4)', justifyContent: 'flex-end' }}>
         <button
           className="wizard-btn wizard-btn-secondary"
-          onClick={() => onBack(4)}
+          onClick={() => onBack(3)}
         >
           ← Back
         </button>

--- a/webview-ui/src/components/WizardStepFeatureDefinition.tsx
+++ b/webview-ui/src/components/WizardStepFeatureDefinition.tsx
@@ -44,7 +44,7 @@ export function WizardStepFeatureDefinition({
       featureWhy,
       featureUserFlow,
     });
-    onNext(4);
+    onNext(2);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -116,7 +116,7 @@ export function WizardStepFeatureDefinition({
       <div className="wizard-actions">
         <button 
           className="wizard-btn wizard-btn-secondary" 
-          onClick={() => onBack(2)}
+          onClick={() => onBack(0)}
           aria-label="Go back to previous step"
         >
           Back

--- a/webview-ui/src/styles.css
+++ b/webview-ui/src/styles.css
@@ -528,12 +528,12 @@ button {
 .card {
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: var(--radius-lg);
-  padding: var(--space-lg);
+  border-radius: var(--radius-5);
+  padding: var(--space-4);
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-3);
 }
 
 .card-header {
@@ -1328,7 +1328,7 @@ button {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-4);
 }
 
 .pbi-type-label {

--- a/webview-ui/src/styles/wizard.css
+++ b/webview-ui/src/styles/wizard.css
@@ -101,9 +101,9 @@
 .wizard-step {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-3);
   background: var(--color-neutral-200);
-  padding: var(--space-5);
+  padding: var(--space-4);
   border-radius: var(--radius-5);
   border: 1px solid var(--color-neutral-300);
   box-shadow: var(--shadow-sm);

--- a/webview-ui/src/views/PbiStudio.tsx
+++ b/webview-ui/src/views/PbiStudio.tsx
@@ -646,7 +646,7 @@ export function PbiStudio({
                     className={`pbi-type-btn${pbiType === 'feature' ? ' active' : ''}`}
                     onClick={() => setPbiType('feature')}
                   >
-                    🆕 New Feature
+                    🆕 New
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

Re-applies wizard UX changes from the previous session that were committed to \eature/pbi-studio-ux-improvements\ but never merged to main (PR #40 was squash-merged before this session's work).

## Changes
- **5-step wizard**: Remove Type/Identity steps → Story → Feature Definition → Business Rules → Details → Technical Considerations
- **AI Generate Story button**: Replace passive 'AI-Ready' indicator with actionable '✨ Generate Story' button with loading state
- **'Complete' → 'Next'**: Details step button renamed
- **'New Feature' → 'New'**: PBI type selector button
- **Card alignment**: Normalize all cards to unified design tokens (\--radius-5\, \--space-4\, \--space-3\)

## Conflict resolution
Resolved merge conflict with CBaldwin's PRs (#42, #44, #46):
- Duplicate PBI type selector block discarded (already moved by CBaldwin in #44)
- Refine with AI panel stays hidden per CBaldwin's #42 demo decision