### PR TITLE
fix: PBI Studio cleanup pt 2 (#52)

### DIFF
--- a/webview-ui/src/components/FeatureWizard.tsx
+++ b/webview-ui/src/components/FeatureWizard.tsx
@@ -24,6 +24,9 @@ export function FeatureWizard({ draftId }: Props) {
   const vscode = useVsCodeApi();
   const announcementRef = useRef<HTMLDivElement>(null);
   const wasGeneratingRef = useRef(false);
+  // Signals that the next WIZARD_DRAFT_LOADED is an AI-triggered refresh
+  // (should update draft data only, not jump the user's current step)
+  const aiReloadRef = useRef(false);
 
   const steps: StepName[] = ['Story', 'Feature Definition', 'Business Rules', 'Technical Details', 'Test Cases', 'Summary'];
 
@@ -45,9 +48,12 @@ export function FeatureWizard({ draftId }: Props) {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data;
       if (message.type === 'AI_PROGRESS') {
+        // Ignore AI events for other drafts or unrelated global AI tasks
+        if (message.payload.draftId && message.payload.draftId !== draftId) return;
         const nowBusy = message.payload.busy;
         if (wasGeneratingRef.current && !nowBusy) {
-          // Generation just finished — reload draft
+          // Generation just finished — reload draft data without moving the step
+          aiReloadRef.current = true;
           vscode.postMessage({ type: 'WIZARD_DRAFT_LOAD', payload: { draftId } });
         }
         wasGeneratingRef.current = nowBusy;
@@ -78,8 +84,14 @@ export function FeatureWizard({ draftId }: Props) {
       if (message.type === 'WIZARD_DRAFT_LOADED') {
         const { draft: loadedDraft, currentStep: savedStep } = message.payload;
         setDraft(loadedDraft);
-        setCurrentStep(Math.min(savedStep || 0, steps.length - 1));
-        setLoading(false);
+        if (aiReloadRef.current) {
+          // AI-triggered refresh: only update draft data, keep user on current step
+          aiReloadRef.current = false;
+        } else {
+          // Initial load: restore saved step (clamped to valid range)
+          setCurrentStep(Math.min(savedStep || 0, steps.length - 1));
+          setLoading(false);
+        }
       }
     };
 

--- a/webview-ui/src/components/WizardStep3Story.tsx
+++ b/webview-ui/src/components/WizardStep3Story.tsx
@@ -24,6 +24,7 @@ export function WizardStep3Story({
   isGenerating = false,
 }: Props) {
   const [aiMode, setAiMode] = useState<AiMode>('Manual');
+  const [title, setTitle] = useState(draft.title || '');
   const [persona, setPersona] = useState('');
   const [want, setWant] = useState('');
   const [benefit, setBenefit] = useState('');
@@ -46,6 +47,11 @@ export function WizardStep3Story({
   useEffect(() => {
     firstFieldRef.current?.focus();
   }, []);
+
+  // Sync title if AI updates draft.title while this step is mounted
+  useEffect(() => {
+    if (draft.title) setTitle(draft.title);
+  }, [draft.title]);
 
   // Parse draft.description back into fields when AI updates it
   useEffect(() => {
@@ -75,6 +81,7 @@ export function WizardStep3Story({
     if (saveTimer) clearTimeout(saveTimer);
     const timer = setTimeout(() => {
       onSave({
+        title,
         description: `As a ${persona}\nI want ${want}\nSo that ${benefit}`,
       });
     }, 500);
@@ -85,6 +92,7 @@ export function WizardStep3Story({
     // Cancel pending blur save and do immediate save on step advance
     if (saveTimer) clearTimeout(saveTimer);
     onSave({
+      title,
       description: `As a ${persona}\nI want ${want}\nSo that ${benefit}`,
     });
     onNext(1);
@@ -138,6 +146,23 @@ export function WizardStep3Story({
         </p>
       </div>
 
+      {/* PBI Title */}
+      <div className="wizard-field">
+        <label htmlFor="pbi-title" className="wizard-field-label required">
+          Title
+        </label>
+        <input
+          id="pbi-title"
+          ref={firstFieldRef}
+          type="text"
+          className="wizard-field-input"
+          placeholder="e.g. Add single sign-on support for admin users"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={handleFieldBlur}
+        />
+      </div>
+
       {/* AI Mode Selector — at top of Story step (Decision #2) */}
       <div className="wizard-mode-selector">
         <div className="wizard-mode-toggle"role="radiogroup" aria-label="AI generation mode">
@@ -186,7 +211,6 @@ export function WizardStep3Story({
         </label>
         <input
           id="persona"
-          ref={firstFieldRef}
           type="text"
           className="wizard-field-input"
           placeholder="e.g. Product Manager, Customer, Admin"
@@ -267,7 +291,12 @@ export function WizardStep3Story({
         <div className="ai-generate-section">
           <button
             className="wizard-btn wizard-btn-primary ai-generate-btn"
-            onClick={() => onGenerateAI?.()}
+            onClick={() => {
+              // Flush pending saves so AI has the latest fields
+              if (saveTimer) clearTimeout(saveTimer);
+              onSave({ title, description: `As a ${persona}\nI want ${want}\nSo that ${benefit}` });
+              onGenerateAI?.();
+            }}
             disabled={!onGenerateAI || isGenerating}
             aria-label="Generate story using AI"
           >

--- a/webview-ui/src/styles/wizard.css
+++ b/webview-ui/src/styles/wizard.css
@@ -27,9 +27,9 @@
   justify-content: space-between;
   gap: var(--space-4);
   padding: var(--space-4);
-  background: var(--color-neutral-200);
+  background: var(--panel);
   border-radius: var(--radius-4);
-  border: 1px solid var(--color-neutral-300);
+  border: 1px solid var(--line);
   align-items: center;
 }
 
@@ -55,12 +55,12 @@
 }
 
 .wizard-progress-step.disabled .wizard-progress-step-indicator {
-  background: var(--color-neutral-250);
-  color: var(--color-neutral-450);
+  background: var(--panel-muted);
+  color: var(--ink-muted);
 }
 
 .wizard-progress-step.disabled .wizard-progress-step-label {
-  color: var(--color-neutral-450);
+  color: var(--ink-muted);
 }
 
 .wizard-progress-step-indicator {
@@ -70,8 +70,8 @@
   width: 32px;
   height: 32px;
   border-radius: var(--radius-pill);
-  background: var(--color-neutral-300);
-  color: var(--color-neutral-500);
+  background: var(--line);
+  color: var(--ink-muted);
   font: var(--typography-button-sm);
   flex-shrink: 0;
   transition: all var(--transition-base);
@@ -93,7 +93,7 @@
 
 .wizard-progress-step-label {
   font: var(--typography-label-md);
-  color: var(--color-neutral-500);
+  color: var(--ink-muted);
   flex: 1;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Closes #52

## Changes

### 1. Fix AI Generate step jump (step 4)
- Added \iReloadRef\ to distinguish AI-triggered draft reloads from initial loads — AI reloads now only update the draft data, not the user's current step
- Scoped \AI_PROGRESS\ handler to this wizard's \draftId\ to prevent cross-draft/global AI events from triggering incorrect reloads

### 2. PBI Title field on step 0
- New **Title** input at the top of WizardStep3Story, auto-focused on mount
- Synced with \draft.title\ via useEffect so AI-generated titles appear immediately
- Saved on blur and on Next; flushed before triggering AI generation

### 3. Progress bar dark mode contrast
- Replaced hardcoded \--color-neutral-*\ tokens with semantic \--panel\, \--line\, \--ink-muted\ tokens that adapt to light/dark VS Code themes
- Applied to progress bar container, step indicators, step labels, and disabled state